### PR TITLE
feat: add get_post_comments method to fetch comments for a post

### DIFF
--- a/src/fishbowlpy/fishbowlapi.py
+++ b/src/fishbowlpy/fishbowlapi.py
@@ -35,5 +35,32 @@ class FishBowlAPI:
         LOGGER.debug(len(dict(data.json())))
         return dict(data.json())
 
-    def get_comments(self):
-        pass
+    def get_post_comments(self, post_id: str, sort: str = 'byDate', start: int = 0, count: int = 20, **kwargs):
+        """Get comments for a specific post.
+        
+        :param post_id: The ID of the post to fetch comments for
+        :param sort: Sort order for comments (default: 'byDate', options: 'byDate', 'byPopularity')
+        :param start: Starting index for pagination (default: 0)
+        :param count: Number of comments to return (default: 20, max: 100)
+        :param **kwargs: Additional query parameters
+        :return: Comments data in JSON format
+        
+        Basic Usage:
+        >>> api = FishBowlAPI(session_key='your_key')
+        >>> comments = api.get_post_comments(post_id='12345')
+        >>> comments = api.get_post_comments(post_id='12345', count=50, sort='byPopularity')
+        """
+        params = {k: v for k, v in locals().items() if v is not None and k not in ['self', 'post_id', 'kwargs']}
+        params.update(kwargs)
+        
+        url = self.__url_manager.get_comments_url(post_id, **params)
+        headers = self.__url_manager.get_headers(self.__session_key)
+        
+        LOGGER.debug(f"Fetching comments for post: {post_id}")
+        LOGGER.debug(f"URL: {url}")
+        
+        data = requests.get(url=url, headers=headers, verify=True, timeout=60)
+        result = dict(data.json())
+        
+        LOGGER.debug(f"Retrieved comments response")
+        return result

--- a/src/fishbowlpy/fishbowlclient.py
+++ b/src/fishbowlpy/fishbowlclient.py
@@ -53,6 +53,7 @@ class FishBowlClient:
     def refresh_session(self):
         """This is a placeholder method that will be used to refresh the session"""
         pass
+    
     def get_bowls_names(self):
         """This is a placeholder method that will be used to get the names of the subscribed bowls"""
         # Hard coded for now
@@ -62,10 +63,27 @@ class FishBowlClient:
     def get_posts(self, bowl_name:str):
         """This method returns the posts in the `bowl_name` in json format.
         
-        :param bowl_nameBowl name from where to get the posts.
+        :param bowl_name: Bowl name from where to get the posts.
         
         :return: Posts in json format.
         """
         return self.__fishbowl_api.get_posts(bowl_name=bowl_name)
     
+    def get_post_comments(self, post_id: str, **kwargs):
+        """This method returns the comments for a given post_id in json format.
         
+        :param post_id: Post ID from where to get the comments.
+        :param sort: Sort order for comments (default: 'byDate', options: 'byDate', 'byPopularity')
+        :param start: Starting index for pagination (default: 0)
+        :param count: Number of comments to return (default: 20)
+        :param **kwargs: Additional parameters for flexible configuration
+        
+        :return: Comments in json format.
+        
+        Basic Usage:
+        >>> from fishbowlpy.fishbowlclient import FishBowlClient
+        >>> client = FishBowlClient()
+        >>> comments = client.get_post_comments(post_id='12345')
+        >>> comments = client.get_post_comments(post_id='12345', count=50, sort='byPopularity')
+        """
+        return self.__fishbowl_api.get_post_comments(post_id=post_id, **kwargs)

--- a/src/fishbowlpy/urlmanager.py
+++ b/src/fishbowlpy/urlmanager.py
@@ -32,3 +32,14 @@ class FishbowlURLManager:
     
     def get_posts_url(self, bowl_id, sort:str='byDate', start:int=0, count:int=20):
         return f"https://api.fishbowlapp.com/v4/feed/{bowl_id}/posts?sort={sort}&skipSystemMessages=true&start={start}&count={count}"
+    
+    def get_comments_url(self, post_id, sort='byDate', start=0, count=20):
+        """Construct URL for fetching comments of a specific post.
+        
+        :param post_id: The ID of the post
+        :param sort: Sort order for comments (default: 'byDate')
+        :param start: Starting index for pagination (default: 0)
+        :param count: Number of comments to fetch (default: 20)
+        :return: Complete URL for comments API endpoint
+        """
+        return f"https://api.fishbowlapp.com/v4/posts/{post_id}/comments?sort={sort}&start={start}&count={count}"


### PR DESCRIPTION
- Implemented get_post_comments() method in FishBowlAPI class
- Added get_comments_url() method in FishbowlURLManager for URL construction
- Added get_post_comments() wrapper method in FishBowlClient class
- Method accepts flexible parameters: post_id, sort, start, count, and **kwargs
- All parameters have default values for quick usage (sort='byDate', start=0, count=20)
- Follows existing code structure and API call patterns
- Added comprehensive docstrings with usage examples
## 🎯 Description
This PR implements a method to fetch comments for a given post ID, as requested in issue #16.

## ✅ Changes Made
- **Added `get_comments_url()` method** to `FishbowlURLManager` class for constructing the comments API endpoint URL
- **Implemented `get_post_comments()` method** in `FishBowlAPI` class to handle the API call
- **Added `get_post_comments()` wrapper method** in `FishBowlClient` class for user-facing interface
- Method accepts `post_id` (required) and optional parameters:
  - `sort` (default: 'byDate') - sorting order ('byDate', 'byPopularity')
  - `start` (default: 0) - starting index for pagination
  - `count` (default: 20) - number of comments to fetch
  - `**kwargs` - additional custom parameters for maximum flexibility
- All parameters have default values for quick usage
- Followed existing code structure and API call patterns consistently
- Added comprehensive docstrings with usage examples

## 📝 Code Structure
The implementation follows the same pattern as existing methods like `get_posts()`:
1. URL construction in `urlmanager.py`
2. API call logic in `fishbowlapi.py`
3. User-facing wrapper in `fishbowlclient.py`

## 🧪 Testing
Ready to be tested with:
```python
from fishbowlpy.fishbowlclient import FishBowlClient
client = FishBowlClient()
comments = client.get_post_comments(post_id='12345')
comments = client.get_post_comments(post_id='12345', count=50, sort='byPopularity')
Resolves #16